### PR TITLE
Add MODULE.bazel support

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,29 @@
+"""Module for the bazel_iwyu repository"""
+
+module(name = "bazel_iwyu")
+
+bazel_dep(name = "abseil-cpp", version = "20240116.2")
+bazel_dep(name = "bazel_skylib", version = "1.5.0")
+bazel_dep(name = "googletest", version = "1.14.0", dev_dependency = True, repo_name = "com_google_googletest")
+
+prebuilt_pkg = use_repo_rule("//bazel:prebuilt_pkg.bzl", "prebuilt_pkg")
+prebuilt_pkg(
+    name = "iwyu_prebuilt_pkg",
+    build_file = "//bazel/iwyu:BUILD.prebuilt_pkg",
+    urls = {
+        "linux-aarch64": [
+            "https://github.com/storypku/bazel_iwyu/releases/download/0.20/iwyu-0.20-aarch64-linux-gnu.tar.xz",
+        ],
+        "linux-x86_64": [
+            "https://github.com/storypku/bazel_iwyu/releases/download/0.20/iwyu-0.20-x86_64-linux-gnu.tar.xz",
+        ],
+    },
+    strip_prefix = {
+        "linux-aarch64": "iwyu-0.20-aarch64-linux-gnu",
+        "linux-x86_64": "iwyu-0.20-x86_64-linux-gnu",
+    },
+    sha256 = {
+        "linux-aarch64": "302db27d867a6d406cc63bdc0b9e23944760654aee550671c9ea527bfdca9032",
+        "linux-x86_64": "684e3e7193d6a8ee77ed485c0378f64e8c13f8a30c0709545d13c8c1655811c5",
+    },
+)


### PR DESCRIPTION
Adding the MODULE.bazel file simplifies the inclusion of this repository for those who are using the new bazel module dependency management system, using the following lines:

```bazel
# User's MODULE.bazel
bazel_dep(name = "bazel_iwyu", version = "0.0.1")
git_override(
    module_name = "bazel_iwyu",
    remote = "https://github.com/storypku/bazel_iwyu",
    commit = "bb102395e553215abd66603bcdeb6e93c66ca6d7",
)

```
I would also suggest you to make this repository available on the [Bazel Central Registry](https://registry.bazel.build/), so that the inclusion becomes even easier:

```bazel
# User's MODULE.bazel
bazel_dep(name = "bazel_iwyu", version = "0.0.1")
```

~The only downside is that I'm not sure overriding the mapping files works properly this way. You may want to move it to the child repository through [extensions](https://bazel.build/external/extension) (that would be my suggestion) or look into [transitions](https://bazel.build/rules/lib/builtins/transition).  Alternatively, the user can always patch the module when they import it in their project using either `git_override` or `single_version_override`.~

Edit: just kidding, the mapping setting override works fine, but since I removed the package name prefix `com_github_storypku_` now it only needs `bazel_iwyu` to work.

```bazel
# User's build file example
build:iwyu --@bazel_iwyu//:iwyu_mappings=@my_repo//tools:iwyu_mappings
build:iwyu --aspects @bazel_iwyu//bazel/iwyu:iwyu.bzl%iwyu_aspect
build:iwyu --output_groups=report
build:iwyu --build_tag_filters=-no-iwyu # To include everything except the rules tagged with "no-iwyu"
```