### PR TITLE
Add external includes to iwyu invocation

### DIFF
--- a/bazel/iwyu/iwyu.bzl
+++ b/bazel/iwyu/iwyu.bzl
@@ -54,6 +54,7 @@ def _run_iwyu(ctx, iwyu_executable, iwyu_mappings, iwyu_options, flags, target, 
 
     args.add_all(compilation_context.quote_includes.to_list(), before_each = "-iquote")
     args.add_all(compilation_context.system_includes.to_list(), before_each = "-isystem")
+    args.add_all(compilation_context.external_includes.to_list(), before_each = "-isystem")
 
     # add source to check
     args.add(infile)


### PR DESCRIPTION
- This uses bazel's [`external_includes`](https://bazel.build/rules/lib/builtins/CompilationContext#external_includes) to account for external dependencies' headers (e.g. `@my_library` in cc_library.deps)
- Current workaround is to manually add paths via bazel flags, e.g. `build:iwyu --copt=-isystem./external/my_library/includes`; with this change this is no longer needed