### PR TITLE
Add option to select an alternative IWYU binary

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,6 +2,16 @@ load("@bazel_skylib//rules:common_settings.bzl", "string_list_flag")
 
 package(default_visibility = ["//visibility:public"])
 
+filegroup(
+    name = "iwyu_executable_default",
+    srcs = ["//bazel/iwyu:prebuilt_iwyu"],
+)
+
+label_flag(
+    name = "iwyu_executable",
+    build_setting_default = ":iwyu_executable_default",
+)
+
 label_flag(
     name = "iwyu_mappings",
     build_setting_default = ":iwyu_mappings_default",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,9 +2,12 @@
 
 module(name = "bazel_iwyu")
 
-bazel_dep(name = "abseil-cpp", version = "20240116.2")
-bazel_dep(name = "bazel_skylib", version = "1.5.0")
-bazel_dep(name = "googletest", version = "1.14.0", dev_dependency = True, repo_name = "com_google_googletest")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+
+bazel_dep(name = "abseil-cpp", version = "20240116.3", dev_dependency = True)
+bazel_dep(name = "googletest", version = "1.14.0.bcr.1", dev_dependency = True, repo_name = "com_google_googletest")
+bazel_dep(name = "platforms", version = "0.0.11", dev_dependency = True)
+bazel_dep(name = "rules_cc", version = "0.1.1", dev_dependency = True)
 
 prebuilt_pkg = use_repo_rule("//bazel:prebuilt_pkg.bzl", "prebuilt_pkg")
 prebuilt_pkg(

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## How To Use
 
-1. In your WORKSPACE file, add
+### In your WORKSPACE file, add
 
 ```python
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
@@ -22,7 +22,7 @@ load("@com_github_storypku_bazel_iwyu//bazel:dependencies.bzl", "bazel_iwyu_depe
 bazel_iwyu_dependencies()
 ```
 
-2. Add the following to your .bazelrc.
+### Add the following to your .bazelrc.
 
 ```
 build:iwyu --aspects @com_github_storypku_bazel_iwyu//bazel/iwyu:iwyu.bzl%iwyu_aspect
@@ -55,13 +55,22 @@ If custom IWYU options should be used, change the line below:
 build:iwyu --@com_github_storypku_bazel_iwyu//:iwyu_opts=--verbose=3,--no_fwd_decls,--cxx17ns,--max_line_length=127
 ```
 
-3. Run IWYU
+### Use you own IWYU binary
+
+by default, bazel_iwyu uses its own prebuilt IWYU.  You can pass a different
+binary with:
+
+```text
+build:iwyu --@bazel_iwyu//:iwyu_executable=<LABEL>
+```
+
+### Run IWYU
 
 ```shell
 bazel build --config=iwyu //path/to/pkg:target
 ```
 
-4. Apply fixes
+### Apply fixes
 
 Create a top-level "external" symlink,
 

--- a/bazel/iwyu/BUILD.bazel
+++ b/bazel/iwyu/BUILD.bazel
@@ -3,9 +3,14 @@ package(default_visibility = ["//visibility:public"])
 sh_binary(
     name = "run_iwyu",
     srcs = ["run_iwyu.sh"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)
+
+sh_binary(
+    name = "prebuilt_iwyu",
+    srcs = ["@iwyu_prebuilt_pkg//:bin/include-what-you-use"],
     data = [
         "@iwyu_prebuilt_pkg//:bin/include-what-you-use",
         "@iwyu_prebuilt_pkg//:include",
     ],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
 )

--- a/bazel/iwyu/iwyu.bzl
+++ b/bazel/iwyu/iwyu.bzl
@@ -19,7 +19,7 @@ def _is_cpp_target(srcs):
 def _is_cuda_target(srcs):
     return any([src.extension in _CUDA_EXTENSIONS for src in srcs])
 
-def _run_iwyu(ctx, iwyu_executable, iwyu_mappings, iwyu_options, flags, target, infile):
+def _run_iwyu(ctx, wrapper, exe, iwyu_mappings, iwyu_options, flags, target, infile):
     compilation_context = target[CcInfo].compilation_context
     outfile = ctx.actions.declare_file(
         "{}.{}.iwyu.txt".format(target.label.name, infile.basename),
@@ -27,6 +27,10 @@ def _run_iwyu(ctx, iwyu_executable, iwyu_mappings, iwyu_options, flags, target, 
 
     # add args specified by iwyu_options, the toolchain, on the command line and rule copts
     args = ctx.actions.args()
+
+    # this is consumed by the wrapper script
+    args.add(exe.files.to_list()[0])
+
     args.add(outfile)
 
     args.add_all(iwyu_options, before_each = "-Xiwyu")
@@ -60,7 +64,7 @@ def _run_iwyu(ctx, iwyu_executable, iwyu_mappings, iwyu_options, flags, target, 
     args.add(infile)
 
     inputs = depset(
-        direct = [infile] + iwyu_mappings,
+        direct = [infile] + iwyu_mappings + ([exe.files_to_run.executable] if exe.files_to_run.executable else []),
         transitive = [compilation_context.headers],
     )
 
@@ -69,7 +73,7 @@ def _run_iwyu(ctx, iwyu_executable, iwyu_mappings, iwyu_options, flags, target, 
         inputs = inputs,
         outputs = [outfile],
         arguments = [args],
-        executable = iwyu_executable,
+        executable = wrapper,
         # It seems no-sandbox was required for x-compilation support
         execution_requirements = {
             "no-sandbox": "1",
@@ -144,7 +148,8 @@ def _iwyu_aspect_impl(target, ctx):
     if len(srcs) == 0 or _is_cuda_target(srcs):
         return []
 
-    iwyu_executable = ctx.attr._iwyu_executable.files_to_run
+    wrapper = ctx.attr._iwyu_wrapper.files_to_run
+    exe = ctx.attr._iwyu_executable
     iwyu_mappings = ctx.attr._iwyu_mappings.files.to_list()
     iwyu_options = ctx.attr._iwyu_opts[BuildSettingInfo].value
 
@@ -158,7 +163,7 @@ def _iwyu_aspect_impl(target, ctx):
     all_flags = _safe_flags(toolchain_flags + rule_flags)
 
     outputs = [
-        _run_iwyu(ctx, iwyu_executable, iwyu_mappings, iwyu_options, all_flags, target, src)
+        _run_iwyu(ctx, wrapper, exe, iwyu_mappings, iwyu_options, all_flags, target, src)
         for src in srcs
     ]
     return [
@@ -173,7 +178,8 @@ iwyu_aspect = aspect(
         "_cc_toolchain": attr.label(
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
         ),
-        "_iwyu_executable": attr.label(default = Label("//bazel/iwyu:run_iwyu")),
+        "_iwyu_wrapper": attr.label(default = Label("//bazel/iwyu:run_iwyu")),
+        "_iwyu_executable": attr.label(default = Label("//:iwyu_executable")),
         "_iwyu_mappings": attr.label(default = Label("//:iwyu_mappings")),
         "_iwyu_opts": attr.label(default = Label("//:iwyu_opts")),
     },

--- a/bazel/iwyu/run_iwyu.sh
+++ b/bazel/iwyu/run_iwyu.sh
@@ -25,11 +25,12 @@ set -euo pipefail
 readonly RED='\033[0;31m'
 readonly RESET='\033[0m'
 
-IWYU_BINARY="$(rlocation iwyu_prebuilt_pkg/bin/include-what-you-use)"
-
 function error() {
   (echo >&2 -e "${RED}[ERROR]${RESET} $*")
 }
+
+IWYU_BINARY="$1"
+shift
 
 OUTPUT="$1"
 shift

--- a/examples/cross_compilation/BUILD
+++ b/examples/cross_compilation/BUILD
@@ -8,19 +8,11 @@ platform(
         "@platforms//cpu:x86_64",
         "@platforms//os:linux",
     ],
-    exec_compatible_with = [
-        "@platforms//cpu:x86_64",
-        "@platforms//os:linux",
-    ],
 )
 
 platform(
     name = "aarch64_platform",
     constraint_values = [
-        "@platforms//cpu:aarch64",
-        "@platforms//os:linux",
-    ],
-    exec_compatible_with = [
         "@platforms//cpu:aarch64",
         "@platforms//os:linux",
     ],
@@ -30,10 +22,6 @@ platform(
     name = "j5_cross_platform",
     constraint_values = [
         "//bazel/soctype:j5",
-    ],
-    exec_compatible_with = [
-        "@platforms//cpu:x86_64",
-        "@platforms//os:linux",
     ],
     parents = [":aarch64_platform"],
 )


### PR DESCRIPTION
Letting users provide an alternative IWYU binary can be useful, considering that IWYU versions and LLVM versions have to correspond and that the one provided by the library is now relatively old.

Moreover, the one provided in the prebuilt package has now gotten a bit old.

In the first two patches, I took the liberty to update some dependencies and fix an unrelated bug.